### PR TITLE
Fixed language to work with windows

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,14 +1,17 @@
 import type { Address, Language, Interaction, LanguageContext } from "@perspect3vism/ad4m";
 import { DbStoreLinkAdapter } from "./linksAdapter";
 import { io } from "socket.io-client";
+import os from 'os';
 
 function interactions(expression: Address): Interaction[] {
   return [];
 }
 
 export default async function create(context: LanguageContext): Promise<Language> {
+  const split = os.platform() === 'win32' ? "\\" : "/";
+
   const linksAdapter = new DbStoreLinkAdapter(context);
-  let languageHash = context.storageDirectory.split("/")[context.storageDirectory.split("/").length - 2];
+  let languageHash = context.storageDirectory.split(split)[context.storageDirectory.split(split).length - 2];
 
   console.log("CENTRALIZED LINK LANGUAGE ATTEMPTING WEBSOCKET CONNECTION WITH GRAPH", languageHash)
   const socket = io('https://centralized-link-store-production.up.railway.app');

--- a/linksAdapter.ts
+++ b/linksAdapter.ts
@@ -1,13 +1,15 @@
 import type { Expression, LinksAdapter, NewLinksObserver, LanguageContext, LinkQuery } from "@perspect3vism/ad4m";
 import type { DID } from "@perspect3vism/ad4m/lib/DID";
 import axios from 'axios'
+import os from 'os';
 
 export class DbStoreLinkAdapter implements LinksAdapter {
   linkCallback?: NewLinksObserver
   languageHash: string
 
   constructor(context: LanguageContext) {
-    this.languageHash = context.storageDirectory.split("/")[context.storageDirectory.split("/").length - 2];
+    const split = os.platform() === 'win32' ? "\\" : "/";
+    this.languageHash = context.storageDirectory.split(split)[context.storageDirectory.split(split).length - 2];
   }
 
   writable(): boolean {


### PR DESCRIPTION
In Linux directory path use forward slash but in windows a backward slash is used which would break the language